### PR TITLE
Fixes #23 - Update workflow to use HTTPS for git.io

### DIFF
--- a/Shorten-URL/shorten_url.py
+++ b/Shorten-URL/shorten_url.py
@@ -22,7 +22,7 @@ api = {
 'j.mp' : {'api_url':'http://api.j.mp/v3//shorten?format=json&login=hzlzh&apiKey=R_e8bcc43adaa5f818cc5d8a544a17d27d&longUrl=','title':'j.mp','des':'http://j.mp/'},
 'is.gd' : {'api_url':'http://is.gd/create.php?format=json&url=','title':'is.gd','des':'http://is.gd/'},
 'v.gd' : {'api_url':'http://v.gd/create.php?format=json&url=','title':'v.gd','des':'http://v.gd/'},
-'git.io' : {'api_url':'http://git.io','title':'git.io','des':'http://git.io/'}
+'git.io' : {'api_url':'https://git.io','title':'git.io','des':'https://git.io/'}
 }
 
 fb = Feedback()


### PR DESCRIPTION
Fixes issue: #23 

## Summary of Change
• Modified git.io url to use HTTPS

## Test Plan
- [x] Invoking Shorten-URL workflow on Alfred pasting a GitHub url and selecting git.io provider should have a git.io url copied to clipboard.

## Screenshot
![isse23-fix](https://user-images.githubusercontent.com/13398997/37952107-b0d8c254-316c-11e8-8b75-ef117d45088c.gif)